### PR TITLE
Add 0.0.0.0 to IPs to treat as private addresses

### DIFF
--- a/lib/private_address_check.rb
+++ b/lib/private_address_check.rb
@@ -10,6 +10,7 @@ module PrivateAddressCheck
     # Loopback
     IPAddr.new("127.0.0.0/8"),
     IPAddr.new("::1/64"),
+    IPAddr.new("0.0.0.0"),
 
     # Link Local,
     IPAddr.new("169.254.0.0/16"),

--- a/test/private_address_check_test.rb
+++ b/test/private_address_check_test.rb
@@ -21,6 +21,7 @@ class PrivateAddressCheckTest < Minitest::Test
     assert PrivateAddressCheck.private_address?("127.0.0.1")
     assert PrivateAddressCheck.private_address?("127.2.2.2")
     assert PrivateAddressCheck.private_address?("::1")
+    assert PrivateAddressCheck.private_address?("0.0.0.0")
   end
 
   def test_private_address_for_link_local_addresses


### PR DESCRIPTION
The IP address `0.0.0.0` (and its malformed variants like `0`) can be used to refer to the localhost.

See http://blog.orange.tw/2017/07/how-i-chained-4-vulnerabilities-on.html?m=1