### PR TITLE
Refer to IANA for special-purpose registry

### DIFF
--- a/lib/private_address_check.rb
+++ b/lib/private_address_check.rb
@@ -6,7 +6,8 @@ require "private_address_check/version"
 module PrivateAddressCheck
   module_function
 
-  # https://en.wikipedia.org/wiki/Reserved_IP_addresses
+  # https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+  # https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
   CIDR_LIST = [
     IPAddr.new("127.0.0.0/8"),     # Loopback
     IPAddr.new("::1/128"),         # Loopback


### PR DESCRIPTION
IANA is more normative than Wikipedia. Wikipedia says:
> Wikipedia cannot guarantee the validity of the information found here.
https://en.wikipedia.org/wiki/Wikipedia:General_disclaimer

Fortunately, IANA has some pages easy to read, so refer to them.