### PR TITLE
Raise PrivateAddressCheck::PrivateConnectionAttemptedError even when host is missing

### DIFF
--- a/lib/private_address_check/tcpsocket_ext.rb
+++ b/lib/private_address_check/tcpsocket_ext.rb
@@ -12,13 +12,19 @@ module PrivateAddressCheck
 end
 
 TCPSocket.class_eval do
+
+  EXCEPTION_WHITELIST = []
+
   alias_method :initialize_without_private_address_check, :initialize
 
   def initialize(remote_host, remote_port, local_host = nil, local_port = nil)
     begin
       initialize_without_private_address_check(remote_host, remote_port, local_host, local_port)
-    rescue Errno::ECONNREFUSED, SocketError
-      private_address_check! remote_host
+    rescue => e
+      unless EXCEPTION_WHITELIST.include? e.class
+        private_address_check! remote_host
+      end
+
       raise
     end
 

--- a/test/private_address_check/tcpsocket_ext_test.rb
+++ b/test/private_address_check/tcpsocket_ext_test.rb
@@ -31,4 +31,12 @@ class TCPSocketExtTest < Minitest::Test
       end
     end
   end
+
+  def test_private_address_not_running
+    assert_raises PrivateAddressCheck::PrivateConnectionAttemptedError do
+      PrivateAddressCheck.only_public_connections do
+        TCPSocket.new("localhost", 1234567)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In fixing the TOC TOU issue the behavior changed in checking addresses. It now will only fail when the server exists. This seems less ideal because assuming the errors are show back to the user, it can reveal what server/ports are locally. For example, a user could enumerate the localhost ports and based on what is "Not Found" vs "Not allowed to use a private address" would leak information about the system.

I feel like this should be handled by the gem, but if not, I can catch this locally around the `private_address_check`'s and cover my use case.