### PR TITLE
Fix TCPSocket in ruby 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rake
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
   NewCops: enable
   Include:
     - Gemfile

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Checks if a URL or hostname would cause a request to a private network (RFC 1918
 
 ## Requirements
 
-- Ruby >= 2.4
+- Ruby >= 2.7
 
 ## Installation
 

--- a/lib/private_address_check/tcpsocket_ext.rb
+++ b/lib/private_address_check/tcpsocket_ext.rb
@@ -14,8 +14,8 @@ end
 TCPSocket.class_eval do
   alias_method :initialize_without_private_address_check, :initialize
 
-  def initialize(*args)
-    initialize_without_private_address_check(*args)
+  def initialize(...)
+    initialize_without_private_address_check(...)
     if Thread.current[:private_address_check] && PrivateAddressCheck.resolves_to_private_address?(remote_address.ip_address)
       raise PrivateAddressCheck::PrivateConnectionAttemptedError
     end

--- a/private_address_check.gemspec
+++ b/private_address_check.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob("{lib,test}/**/*.rb") + %w[CODE_OF_CONDUCT.md Gemfile LICENSE.txt README.md Rakefile]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.7.0"
 end

--- a/test/private_address_check/tcpsocket_ext_test.rb
+++ b/test/private_address_check/tcpsocket_ext_test.rb
@@ -31,4 +31,18 @@ class TCPSocketExtTest < Minitest::Test
       end
     end
   end
+
+  # Ruby 4 added an open_timeout kwarg to TCPSocket.new/open.
+  # This is the same check used in https://github.com/ruby/net-http/blob/d7103a1b2c48addb22f87e8ad6713fa4e4f931c4/lib/net/http.rb#L1783
+  if Socket.method(:tcp).parameters.include?([:key, :open_timeout])
+    def test_public_address_with_timeout
+      connected = false
+      PrivateAddressCheck.only_public_connections do
+        TCPSocket.new("example.com", 80, open_timeout: 30)
+        connected = true
+      end
+
+      assert connected
+    end
+  end
 end


### PR DESCRIPTION
tcpsocket_ext  isn't compatible with the new open_timeout option, used by Net::HTTP in ruby 4. This raises an error - 

```ruby
require 'private_address_check/tcpsocket_ext'
URI.open('https://google.com/')
```
```
tcpsocket_ext.rb:18:in 'TCPSocket#initialize': Failed to open TCP connection to google.com:443
  (wrong number of arguments (given 5, expected 2..4)) (ArgumentError)
```

I've fixed this by changing TCPSocket:

```diff
- def initialize(*args)
+ def initialize(...)
```

which means raising the minimum ruby version to 2.7. WDYT?