### PR TITLE
require private_address_check from private_address_check/tcpsocket_ext

### DIFF
--- a/lib/private_address_check/tcpsocket_ext.rb
+++ b/lib/private_address_check/tcpsocket_ext.rb
@@ -1,3 +1,5 @@
+require "private_address_check"
+
 module PrivateAddressCheck
   PrivateConnectionAttemptedError = Class.new(StandardError)
 


### PR DESCRIPTION
Otherwise if `private_address_check` or `socket` is not required before that, there will be a `NameError` due to missing `TCPSocket` and then a `NoMethodError` due to `resolves_to_private_address?` not being defined:

```ruby
require 'private_address_check/tcpsocket_ext' # => uninitialized constant TCPSocket (NameError)
```
```ruby
require 'net/http'
require 'uri'
require 'socket'
require 'private_address_check/tcpsocket_ext'

PrivateAddressCheck.only_public_connections do
  Net::HTTP.get_response(URI.parse('https://github.com')) # => undefined method 'resolves_to_private_address?' for module PrivateAddressCheck (NoMethodError)
end
```

After the change:
```ruby
require 'net/http'
require 'uri'
require 'private_address_check/tcpsocket_ext'

PrivateAddressCheck.only_public_connections do
  Net::HTTP.get_response(URI.parse('https://github.com'))
end
```
